### PR TITLE
Remove versions from paths to systemjs and s6-module-loader

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -60,12 +60,18 @@ module.exports = function(files, basePath, jspm, client) {
   files.unshift(createServedPattern(packagesPath + '**/*'));
 
   // Add SystemJS loader and jspm config
+  function getLoaderPath(fileName){
+    var exists = glob.sync(packagesPath + fileName + '@*.js');
+    if(exists && exists.length != 0){
+      return packagesPath + fileName + '@*.js';
+    } else {
+      return packagesPath + fileName + '.js';
+    }
+  }
   files.unshift(createPattern(__dirname + '/adapter.js'));
   files.unshift(createPattern(configPath));
-  files.unshift(createPattern(packagesPath + 'system.js'));
-  files.unshift(createPattern(packagesPath + 'system@*.js'));
-  files.unshift(createPattern(packagesPath + 'es6-module-loader.js'));
-  files.unshift(createPattern(packagesPath + 'es6-module-loader@*.js'));
+  files.unshift(createPattern(getLoaderPath('system')));
+  files.unshift(createPattern(getLoaderPath('es6-module-loader')));
 
   // Loop through all of jspm.load_files and do two things
   // 1. Add all the files as "served" files to the files array

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -21,32 +21,22 @@ describe('jspm plugin init', function(){
     });
 
     it('should add adapter.js to the top of the files array', function(){
-        expect(files[5].pattern).toEqual(cwd + '/src/adapter.js');
-        expect(files[5].included).toEqual(true);
-    });
-
-    it('should add config.js to the top of the files array', function(){
-        expect(files[4].pattern).toEqual(cwd + '/custom_config.js');
-        expect(files[4].included).toEqual(true);
-    });
-
-    it('should add systemjs to the top of the files array', function(){
-        expect(files[3].pattern).toEqual(cwd + '/custom_packages/system.js');
+        expect(files[3].pattern).toEqual(cwd + '/src/adapter.js');
         expect(files[3].included).toEqual(true);
     });
 
-    it('should add systemjs@* to the top of the files array', function(){
-        expect(files[2].pattern).toEqual(cwd + '/custom_packages/system@*.js');
+    it('should add config.js to the top of the files array', function(){
+        expect(files[2].pattern).toEqual(cwd + '/custom_config.js');
         expect(files[2].included).toEqual(true);
     });
 
-    it('should add es6-module-loader to the top of the files array', function(){
-        expect(files[1].pattern).toEqual(cwd + '/custom_packages/es6-module-loader.js');
+    it('should add systemjs to the top of the files array', function(){
+        expect(files[1].pattern).toEqual(cwd + '/custom_packages/system.js');
         expect(files[1].included).toEqual(true);
     });
 
-    it('should add es6-module-loader@* to the top of the files array', function(){
-        expect(files[0].pattern).toEqual(cwd + '/custom_packages/es6-module-loader@*.js');
+    it('should add es6-module-loader to the top of the files array', function(){
+        expect(files[0].pattern).toEqual(cwd + '/custom_packages/es6-module-loader.js');
         expect(files[0].included).toEqual(true);
     });
 
@@ -62,10 +52,10 @@ describe('jspm plugin init', function(){
     });
 
     it('should use the configured jspm_packages path and include it in the files array', function(){
-        expect(files[6].pattern).toEqual(path.resolve(cwd, './custom_packages/**/*'));
-        expect(files[6].included).toEqual(false);
-        expect(files[6].served).toEqual(true);
-        expect(files[6].watched).toEqual(true);
+        expect(files[4].pattern).toEqual(path.resolve(cwd, './custom_packages/**/*'));
+        expect(files[4].included).toEqual(false);
+        expect(files[4].served).toEqual(true);
+        expect(files[4].watched).toEqual(true);
     });
 
 });


### PR DESCRIPTION
Fixes #10. Should be released as a new breaking change (either `1.1.0` or `2.0.0`).
## Problem

jspm no longer puts a version string in the filenames for system.js and es6-module-loader.js after version 0.8.0
## Solution

Update the file paths to these files.
## Testing

Use karma-jspm in a project that is using jspm@0.8.0-beta.4

@trentgrover-wf 
