### PR TITLE
CP-344 Karma-jspm IE8 fix

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -46,8 +46,8 @@
     // Load everything specified in loadFiles
     for (var i = 0; i < karma.config.jspm.expandedFiles.length; i++) {
         var modulePath = karma.config.jspm.expandedFiles[i];
-        var promise = System.import(extractModuleName(modulePath))
-            .catch(function(e){
+        var promise = System['import'](extractModuleName(modulePath))
+            ['catch'](function(e){
                 setTimeout(function() {
                     throw e;
                 });


### PR DESCRIPTION
## Problem
- can't use karma-jspm to test in IE8

## Solution
- `System['import']` instead of `System.import`
- `['catch']` instead of `.catch`

## Testing
- unit tests pass

@maxwellpeterson-wf 
@evanweible-wf 
@charliekump-wf 
@jayudey-wf 