### PR TITLE
CP-380 properly declare variables as local, not as globals

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -76,8 +76,8 @@ module.exports = function(files, basePath, jspm, client) {
   // Pass on useBundles option to client
   client.jspm.useBundles = jspm.useBundles;
 
-  packagesPath = path.normalize(cwd + '/' + jspm.packages + '/');
-  configPath = path.normalize(cwd + '/' + jspm.config);
+  var packagesPath = path.normalize(cwd + '/' + jspm.packages + '/');
+  var configPath = path.normalize(cwd + '/' + jspm.config);
 
   // Allow Karma to serve all files within jspm_packages.
   // This allows jspm/SystemJS to load them


### PR DESCRIPTION
that's like the first rule of javascript

![dafuq](http://memecrunch.com/meme/BXXR/impossibru-jackie-chan/image.jpg?w=400&c=1)