### PR TITLE
CP-591 customizable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,15 @@ By default karma-jspm ignores jspm's bundles configuration. To re-enable it, spe
 jspm: {
     useBundles: true
 }
+
+Depending on your framework and project structure it might be necessary to override jspm paths for the testing scenario.
+In order to do so just add the `paths` property to the jspm config object in your karma-configuration file, along with the overrides:
+ 
+```js
+jspm: {
+    paths: {
+        '*': 'yourpath/*.js',
+        ...
+    }
+}
+``` 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ By default karma-jspm ignores jspm's bundles configuration. To re-enable it, spe
 jspm: {
     useBundles: true
 }
+```
 
 Depending on your framework and project structure it might be necessary to override jspm paths for the testing scenario.
 In order to do so just add the `paths` property to the jspm config object in your karma-configuration file, along with the overrides:

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -50,10 +50,6 @@
         });
     }
 
-    if(typeof karma.config.jspm.paths === 'object') {
-
-    }
-
     // Load everything specified in loadFiles
     for (var i = 0; i < karma.config.jspm.expandedFiles.length; i++) {
         var modulePath = karma.config.jspm.expandedFiles[i];

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -36,11 +36,22 @@
         baseURL: 'base'
     });
 
+    if(karma.config.jspm.paths !== undefined &&
+        typeof karma.config.jspm.paths === 'object') {
+        System.config({
+            paths: karma.config.jspm.paths
+        });
+    }
+
     // Exclude bundle configurations if useBundles option is not specified
     if(!karma.config.jspm.useBundles){
         System.config({
             bundles: []
         });
+    }
+
+    if(typeof karma.config.jspm.paths === 'object') {
+
     }
 
     // Load everything specified in loadFiles

--- a/src/init.js
+++ b/src/init.js
@@ -72,6 +72,8 @@ module.exports = function(files, basePath, jspm, client) {
     jspm.packages = getJspmPackageJson(cwd).directories.packages || "jspm_packages/";
   if(!client.jspm)
     client.jspm = {};
+  if(jspm.paths !== undefined && typeof jspm.paths === 'object')
+    client.jspm.paths = jspm.paths;
 
   // Pass on useBundles option to client
   client.jspm.useBundles = jspm.useBundles;


### PR DESCRIPTION
if the jspm conf section inside the karma.conf file contains a paths object, this will be used to override path settings. This is helpful if your test environment needs to have different basepaths compared to your production environment.

The Aurelia Team uses karma-jspm as a core workflow tool for unit testing across all repos. This feature would be very important in order to get our test suite working properly.