### PR TITLE
CP-545 Allow karma (with karma-jspm) to be run from different directory then karma.conf.js file's dir

### DIFF
--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -5,7 +5,7 @@ var initJspm = require('../src/init');
 
 describe('jspm plugin init', function(){
     var files, jspm, client;
-    var basePath = ".";
+    var basePath = path.resolve(__dirname, '..');
 
     beforeEach(function(){
         files = [];
@@ -21,22 +21,22 @@ describe('jspm plugin init', function(){
     });
 
     it('should add adapter.js to the top of the files array', function(){
-        expect(files[3].pattern).toEqual(cwd + '/src/adapter.js');
+        expect(files[3].pattern).toEqual(basePath + '/src/adapter.js');
         expect(files[3].included).toEqual(true);
     });
 
     it('should add config.js to the top of the files array', function(){
-        expect(files[2].pattern).toEqual(cwd + '/custom_config.js');
+        expect(files[2].pattern).toEqual(basePath + '/custom_config.js');
         expect(files[2].included).toEqual(true);
     });
 
     it('should add systemjs to the top of the files array', function(){
-        expect(files[1].pattern).toEqual(cwd + '/custom_packages/system.js');
+        expect(files[1].pattern).toEqual(basePath + '/custom_packages/system.js');
         expect(files[1].included).toEqual(true);
     });
 
     it('should add es6-module-loader to the top of the files array', function(){
-        expect(files[0].pattern).toEqual(cwd + '/custom_packages/es6-module-loader.js');
+        expect(files[0].pattern).toEqual(basePath + '/custom_packages/es6-module-loader.js');
         expect(files[0].included).toEqual(true);
     });
 


### PR DESCRIPTION
If you would try to run karma from different directory then the one where the karma.conf.js is located then karma-jspm would not resolve file locations correctly. This is due to usage of process.cwd() instead of basePath.
This pull request fixes this issue.