### PR TITLE
CP-727 Fix compatibility with SystemJS 0.17+

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -49,11 +49,6 @@
                         "or by running 'jspm dl-loader'.");
     }
 
-    // Configure SystemJS baseURL
-    System.config({
-        baseURL: 'base'
-    });
-
     if(karma.config.jspm.paths !== undefined &&
         typeof karma.config.jspm.paths === 'object') {
         System.config({

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -15,9 +15,27 @@
  */
 
 (function(karma, System) {
+    System.config({ baseURL: 'base' });
 
     // Prevent immediately starting tests.
-    window.__karma__.loaded = function() {};
+    window.__karma__.loaded = function() {
+        // Load everything specified in loadFiles
+        for (var i = 0; i < karma.config.jspm.expandedFiles.length; i++) {
+            var modulePath = karma.config.jspm.expandedFiles[i];
+            var promise = System['import'](extractModuleName(modulePath))
+                ['catch'](function(e){
+                    setTimeout(function() {
+                        throw e;
+                    });
+                });
+            promises.push(promise);
+        }
+
+        // Promise comes from the es6_module_loader
+        Promise.all(promises).then(function(){
+            karma.start();
+        });
+    };
 
     function extractModuleName(fileName){
         return fileName.replace(/\.js$/, "");
@@ -49,22 +67,4 @@
             bundles: []
         });
     }
-
-    // Load everything specified in loadFiles
-    for (var i = 0; i < karma.config.jspm.expandedFiles.length; i++) {
-        var modulePath = karma.config.jspm.expandedFiles[i];
-        var promise = System['import'](extractModuleName(modulePath))
-            ['catch'](function(e){
-                setTimeout(function() {
-                    throw e;
-                });
-            });
-        promises.push(promise);
-    }
-
-    // Promise comes from the es6_module_loader
-    Promise.all(promises).then(function(){
-        karma.start();
-    });
-
 })(window.__karma__, window.System);

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -31,7 +31,7 @@
             promises.push(promise);
         }
 
-        // Promise comes from the es6_module_loader
+        // Promise comes from the systemjs polyfills
         Promise.all(promises).then(function(){
             karma.start();
         });

--- a/src/init.js
+++ b/src/init.js
@@ -93,10 +93,10 @@ module.exports = function(files, basePath, jspm, client) {
       return packagesPath + fileName + '.js';
     }
   }
-  files.unshift(createPattern(__dirname + '/adapter.js'));
   files.unshift(createPattern(configPath));
-  files.unshift(createPattern(getLoaderPath('system')));
-  files.unshift(createPattern(getLoaderPath('es6-module-loader')));
+  files.unshift(createPattern(__dirname + '/adapter.js'));
+  files.unshift(createPattern(getLoaderPath('system-polyfills.src')));
+  files.unshift(createPattern(getLoaderPath('system.src')));
 
   // Loop through all of jspm.load_files and do two things
   // 1. Add all the files as "served" files to the files array

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -20,23 +20,23 @@ describe('jspm plugin init', function(){
         initJspm(files, basePath, jspm, client);
     });
 
-    it('should add adapter.js to the top of the files array', function(){
-        expect(files[3].pattern).toEqual(basePath + '/src/adapter.js');
+    it('should add config.js to the top of the files array', function(){
+        expect(files[3].pattern).toEqual(basePath + '/custom_config.js');
         expect(files[3].included).toEqual(true);
     });
 
-    it('should add config.js to the top of the files array', function(){
-        expect(files[2].pattern).toEqual(basePath + '/custom_config.js');
+    it('should add adapter.js to the top of the files array', function(){
+        expect(files[2].pattern).toEqual(basePath + '/src/adapter.js');
         expect(files[2].included).toEqual(true);
     });
 
-    it('should add systemjs to the top of the files array', function(){
-        expect(files[1].pattern).toEqual(basePath + '/custom_packages/system.js');
+    it('should add systemjs-polyfills to the top of the files array', function(){
+        expect(files[1].pattern).toEqual(basePath + '/custom_packages/system-polyfills.src.js');
         expect(files[1].included).toEqual(true);
     });
 
-    it('should add es6-module-loader to the top of the files array', function(){
-        expect(files[0].pattern).toEqual(basePath + '/custom_packages/es6-module-loader.js');
+    it('should add systemjs to the top of the files array', function(){
+        expect(files[0].pattern).toEqual(basePath + '/custom_packages/system.src.js');
         expect(files[0].included).toEqual(true);
     });
 


### PR DESCRIPTION
SystemJS 0.17+ requires the baseURL to be configured first and doesn't allow to change it once set. Also, es6-module-loader is not needed anymore. It has been replaced with systemjs-polyfills which are a stripped down version of es6-module-loader.