### PR TITLE
Fix for working with systemjs 0.17+ without getting 404s

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 
-(function(karma, System) {
-    System.config({ baseURL: 'base' });
+function configureSystem(config) {
+    var baseURLPattern = /(["']baseURL["']:.*["'])(.*)(["'])/;
+
+    // Fix baseURL path, by injecting base instead of the current value from config.js
+    var jspmConfig = config.replace(baseURLPattern, '$1base$3');
+    
+    // Evel the config
+    eval(jspmConfig); 
+}
+
+(function(karma, System) {    
+    configureSystem(karma.config.jspm.config);
 
     // Prevent immediately starting tests.
     window.__karma__.loaded = function() {

--- a/src/init.js
+++ b/src/init.js
@@ -58,6 +58,7 @@ function getJspmPackageJson(dir) {
 }
 
 module.exports = function(files, basePath, jspm, client) {
+  console.log(getJspmPackageJson(basePath).directories.packages);
   // Initialize jspm config if it wasn't specified in karma.conf.js
   if(!jspm)
     jspm = {};

--- a/src/init.js
+++ b/src/init.js
@@ -96,7 +96,7 @@ module.exports = function(files, basePath, jspm, client) {
   
   files.unshift(createPattern(__dirname + '/adapter.js'));
   files.unshift(createPattern(getLoaderPath('system-polyfills.src')));
-  files.unshift(createPattern(getLoaderPath('system.src')));  
+  files.unshift(createPattern(getLoaderPath('system.src')));
 
   // Loop through all of jspm.load_files and do two things
   // 1. Add all the files as "served" files to the files array

--- a/src/init.js
+++ b/src/init.js
@@ -58,7 +58,6 @@ function getJspmPackageJson(dir) {
 }
 
 module.exports = function(files, basePath, jspm, client) {
-  console.log(getJspmPackageJson(basePath).directories.packages);
   // Initialize jspm config if it wasn't specified in karma.conf.js
   if(!jspm)
     jspm = {};

--- a/src/init.js
+++ b/src/init.js
@@ -108,7 +108,13 @@ module.exports = function(files, basePath, jspm, client) {
   }));
 
   // Inject the jspm config for later evaluation
-  client.jspm.config = fs.readFileSync(configPath).toString();
+  if (fs.existsSync(configPath)) {
+    client.jspm.config = fs.readFileSync(configPath).toString();
+  } else {
+    client.jspm.config = {
+        baseURL: 'base'
+    };
+  }
 
   // Add served files to files array
   jspm.serveFiles.map(function(file){

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -51,10 +51,10 @@ describe('jspm plugin init', function(){
     });
 
     it('should use the configured jspm_packages path and include it in the files array', function(){
-        expect(files[4].pattern).toEqual(path.resolve(cwd, './custom_packages/**/*'));
-        expect(files[4].included).toEqual(false);
-        expect(files[4].served).toEqual(true);
-        expect(files[4].watched).toEqual(true);
+        expect(files[3].pattern).toEqual(path.resolve(cwd, './custom_packages/**/*'));
+        expect(files[3].included).toEqual(false);
+        expect(files[3].served).toEqual(true);
+        expect(files[3].watched).toEqual(true);
     });
 
 });

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -20,9 +20,8 @@ describe('jspm plugin init', function(){
         initJspm(files, basePath, jspm, client);
     });
 
-    it('should add config.js to the top of the files array', function(){
-        expect(files[3].pattern).toEqual(basePath + '/custom_config.js');
-        expect(files[3].included).toEqual(true);
+    it('should add inject the config for later evaluation', function(){
+        expect(client.jspm.config).not.toBe(false);
     });
 
     it('should add adapter.js to the top of the files array', function(){


### PR DESCRIPTION
Not sure if it is the best way of approaching the issue. 
The issue:
The jspm's config.js file was being loaded after the adapter.js file. Therefore, overriding the adapter's baseURL setting (baseURL: 'base'). On the other hand, making config.js load before adapter.js, doesn't work since as of SystemJs 0.17, you can't set baseURL twice. I am not getting into why it worked when config.js was actually setting baseURL a second time. 

The solution:
Instead of setting the configuration twice, once via config.js, and once via adapter.js. We are passing the configuration on to adapter.js, which in turn, injects the correct baseURL into the configuration. After injecting the correct baseURL, we are setting the configuration on SystemJS.
