### PR TITLE
CP-837 Fix to honor the "useBundles" jspm Karma configuration option

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -29,9 +29,7 @@
 
         // Exclude bundle configurations if useBundles option is not specified
         if(!karma.config.jspm.useBundles){
-            System.config({
-                bundles: []
-            });
+            System.bundles = [];
         }
         
         // Load everything specified in loadFiles


### PR DESCRIPTION
In my karma.conf.js file I was using the jspm { useBundles: false } configuration as shown below.  It wasn't honoring that setting and was trying to load my bundles even if I set it to false.  My change is to move where the exclusion of the SystemJS bundles is performed, and changes how we do it.

In the 0.18.x versions of SystemJS, they only add or update to existing bundle configuration with the System.config method.  See [core.js](https://github.com/systemjs/systemjs/blob/master/lib/core.js).  You can't set it back to an empty map with System.config.

karma-jspm is loading in my "./config.js" file which has bundles defined in it and then it's being configured and can't be removed with the System.config call.  I'm open to alternative implementations, but this one is working for me locally.

I can produce a small sample project to show the issue if that helps.

```javascript
module.exports = function(config) {
  config.set({
    ...
    ...
    jspm: {
        useBundles: false
    }
    ...
    ...
  })
}

```
