### PR TITLE
 CP-821 Move overrides to after karma has loaded

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -19,6 +19,21 @@
 
     // Prevent immediately starting tests.
     window.__karma__.loaded = function() {
+
+        if(karma.config.jspm.paths !== undefined &&
+            typeof karma.config.jspm.paths === 'object') {
+            System.config({
+                paths: karma.config.jspm.paths
+            });
+        }
+
+        // Exclude bundle configurations if useBundles option is not specified
+        if(!karma.config.jspm.useBundles){
+            System.config({
+                bundles: []
+            });
+        }
+        
         // Load everything specified in loadFiles
         for (var i = 0; i < karma.config.jspm.expandedFiles.length; i++) {
             var modulePath = karma.config.jspm.expandedFiles[i];
@@ -47,19 +62,5 @@
         throw new Error("SystemJS was not found. Please make sure you have " +
                         "initialized jspm via installing a dependency with jspm, " +
                         "or by running 'jspm dl-loader'.");
-    }
-
-    if(karma.config.jspm.paths !== undefined &&
-        typeof karma.config.jspm.paths === 'object') {
-        System.config({
-            paths: karma.config.jspm.paths
-        });
-    }
-
-    // Exclude bundle configurations if useBundles option is not specified
-    if(!karma.config.jspm.useBundles){
-        System.config({
-            bundles: []
-        });
     }
 })(window.__karma__, window.System);


### PR DESCRIPTION
fixes https://github.com/Workiva/karma-jspm/issues/77

Config.js is loaded after the overrides causing 404 errors on all files. When you move the override to after karma has loaded, the overrides work and tests run normally again.