### PR TITLE
CP-1061 Import modules in the order they were specified in config

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -23,8 +23,7 @@
 
     System.config({ baseURL: 'base' });
 
-    var promises = [],
-      stripExtension = typeof karma.config.jspm.stripExtension === 'boolean' ? karma.config.jspm.stripExtension : true;
+    var stripExtension = typeof karma.config.jspm.stripExtension === 'boolean' ? karma.config.jspm.stripExtension : true;
 
     // Prevent immediately starting tests.
     karma.loaded = function() {
@@ -40,20 +39,21 @@
         if(!karma.config.jspm.useBundles){
             System.bundles = [];
         }
-        
-        // Load everything specified in loadFiles
+
+        // Load everything specified in loadFiles in the specified order
+        var promiseChain = Promise.resolve();
         for (var i = 0; i < karma.config.jspm.expandedFiles.length; i++) {
-            var modulePath = karma.config.jspm.expandedFiles[i];
-            var promise = System['import'](extractModuleName(modulePath))
-                ['catch'](function(e) {
-                    throw e;
-                });
-            promises.push(promise);
+            promiseChain = promiseChain.then((function (moduleName) {
+                return function () {
+                    return System['import'](moduleName);
+                };
+            })(extractModuleName(karma.config.jspm.expandedFiles[i])));
         }
 
-        // Promise comes from the systemjs polyfills
-        Promise.all(promises).then(function() {
+        promiseChain.then(function () {
             karma.start();
+        }, function (e) {
+            throw e;
         });
     };
 


### PR DESCRIPTION
We would like to make the order, in which modules are loaded, deterministic. They should be imported in the order specified in `karma.conf.js`. E.g. given this configuration:

    jspm: {
      serveFiles: ['**/*'],
      loadFiles: ['polyfills.js', '**/*.specs.js']
    }

The current implementation would attempt to load all modules simultaneously. This can lead to different behavior between test runs, especially in the above case, where the first module adds some global polyfills other modules rely on.

With this changeset, all files specified in the `loadFiles` array will be imported sequentially.

From a perfomance perspective: we could not notice any difference between simultaneous/sequential import, tested in a project with about 400 tests and about 170 modules.