### PR TITLE
CP-1068 Fixes #104: Module interpreted as global module format

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -36,6 +36,13 @@
             });
         }
 
+        if(karma.config.jspm.meta !== undefined &&
+            typeof karma.config.jspm.meta === 'object') {
+            System.config({
+                meta: karma.config.jspm.meta
+            });
+        }
+
         // Exclude bundle configurations if useBundles option is not specified
         if(!karma.config.jspm.useBundles){
             System.bundles = [];

--- a/src/init.js
+++ b/src/init.js
@@ -73,6 +73,8 @@ module.exports = function(files, basePath, jspm, client) {
     client.jspm = {};
   if(jspm.paths !== undefined && typeof jspm.paths === 'object')
     client.jspm.paths = jspm.paths;
+  if(jspm.meta !== undefined && typeof jspm.meta === 'object')
+    client.jspm.meta = jspm.meta;
 
   // Pass on options to client
   client.jspm.useBundles = jspm.useBundles;


### PR DESCRIPTION
Fixes #104 

Error: Module interpreted as global module format, but called System register
Solution: Add support to custom meta in karma-jspm config.

Thanks @larrifax for the help.