### PR TITLE
Only set SystemJS baseURL once

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -21,7 +21,9 @@
             "or by running 'jspm dl-loader'.");
     }
 
-    System.config({ baseURL: 'base' });
+    if (!System.baseURL) {
+        System.config({ baseURL: 'base' });
+    }
 
     var stripExtension = typeof karma.config.jspm.stripExtension === 'boolean' ? karma.config.jspm.stripExtension : true;
 


### PR DESCRIPTION
This is a proposed fix for #106.

Using some setups karma-jspm will try to set SystemJS.baseURL a second time.