### PR TITLE
CP-1340 feat(config): nocache support for jspm.loadFiles Closes #114  (additionally #113)

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -31,8 +31,9 @@ var createPattern = function(path) {
   return {pattern: path, included: true, served: true, watched: false};
 };
 
-var createServedPattern = function(path){
-  return {pattern: path, included: false, served: true, watched: true};
+var createServedPattern = function(path, nocache){
+  nocache = nocache || false;
+  return {pattern: path, included: false, served: true, nocache:nocache, watched: true};
 };
 
 function getJspmPackageJson(dir) {
@@ -108,7 +109,7 @@ module.exports = function(files, basePath, jspm, client) {
   // 2. Expand out and globs to end up with actual files for jspm to load.
   //    Store that in client.jspm.expandedFiles
   client.jspm.expandedFiles = flatten(jspm.loadFiles.map(function(file){
-    files.push(createServedPattern(basePath + "/" + (file.pattern || file)));
+    files.push(createServedPattern(basePath + "/" + (file.pattern || file), file.nocache || false));
     return expandGlob(file, basePath);
   }));
 

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -2,6 +2,9 @@ var cwd = process.cwd();
 var path = require('path');
 var initJspm = require('../src/init');
 
+var normalPath = function(path){
+    return path.replace(/\\/g,'/');
+}
 
 describe('jspm plugin init', function(){
     var files, jspm, client;
@@ -11,7 +14,7 @@ describe('jspm plugin init', function(){
         files = [];
         jspm = {
             config: 'custom_config.js',
-            loadFiles: ['src/**/*.js'],
+            loadFiles: ['src/**/*.js',{pattern:'not-cached.js', nocache:true}],
             packages: 'custom_packages/',
             serveFiles: ['testfile.js']
         };
@@ -21,22 +24,22 @@ describe('jspm plugin init', function(){
     });
 
     it('should add config.js to the top of the files array', function(){
-        expect(files[3].pattern).toEqual(basePath + '/custom_config.js');
+        expect(normalPath(files[3].pattern)).toEqual(normalPath(basePath + '/custom_config.js'));
         expect(files[3].included).toEqual(true);
     });
 
     it('should add adapter.js to the top of the files array', function(){
-        expect(files[2].pattern).toEqual(basePath + '/src/adapter.js');
+        expect(normalPath(files[2].pattern)).toEqual(normalPath(basePath + '/src/adapter.js'));
         expect(files[2].included).toEqual(true);
     });
 
     it('should add systemjs-polyfills to the top of the files array', function(){
-        expect(files[1].pattern).toEqual(basePath + '/custom_packages/system-polyfills.src.js');
+        expect(normalPath(files[1].pattern)).toEqual(normalPath(basePath + '/custom_packages/system-polyfills.src.js'));
         expect(files[1].included).toEqual(true);
     });
 
     it('should add systemjs to the top of the files array', function(){
-        expect(files[0].pattern).toEqual(basePath + '/custom_packages/system.src.js');
+        expect(normalPath(files[0].pattern)).toEqual(normalPath(basePath + '/custom_packages/system.src.js'));
         expect(files[0].included).toEqual(true);
     });
 
@@ -45,17 +48,24 @@ describe('jspm plugin init', function(){
     });
 
     it('should add files from jspm.serveFiles to the end of the files array as served files', function(){
-        expect(files[files.length - 1].pattern).toEqual(cwd + '/testfile.js');
+        expect(normalPath(files[files.length - 1].pattern)).toEqual(normalPath(cwd + '/testfile.js'));
         expect(files[files.length - 1].included).toEqual(false);
         expect(files[files.length - 1].served).toEqual(true);
         expect(files[files.length - 1].watched).toEqual(true);
     });
 
     it('should use the configured jspm_packages path and include it in the files array', function(){
-        expect(files[4].pattern).toEqual(path.resolve(cwd, './custom_packages/**/*'));
+        expect(normalPath(files[4].pattern)).toEqual(normalPath(path.resolve(cwd, './custom_packages/**/*')));
         expect(files[4].included).toEqual(false);
         expect(files[4].served).toEqual(true);
         expect(files[4].watched).toEqual(false); 
     });
 
+    it('should assign true to nocache option to served files with nocache option in jspm.loadFiles', function(){
+        expect(normalPath(files[files.length - 2].pattern)).toEqual(normalPath(cwd + '/not-cached.js'));
+        expect(files[files.length - 2].included).toEqual(false);
+        expect(files[files.length - 2].served).toEqual(true);
+        expect(files[files.length - 2].watched).toEqual(true);
+        expect(files[files.length - 2].nocache).toEqual(true);
+    });
 });


### PR DESCRIPTION
Forces file reread in watch cycle
(required for tests in current edit)
Additionally common problem with testing on windows fixed

Closes #114 #113