### PR TITLE
CP-1358 Add option to not cache jspm_packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,11 @@ jspm: {
     stripExtension: false
 }
 ```
+
+Most of the time, you do not want to cache your entire jspm_packages directory, but serve it from the disk. This is done by default, but can be reversed as follows:
+
+```js
+jspm: {
+    cachePackages: true
+}
+```

--- a/src/init.js
+++ b/src/init.js
@@ -86,7 +86,7 @@ module.exports = function(files, basePath, jspm, client) {
 
   // Allow Karma to serve all files within jspm_packages.
   // This allows jspm/SystemJS to load them
-  var jspmPattern = createServedPattern(packagesPath + '**/*');
+  var jspmPattern = createServedPattern(packagesPath + '**/*', jspm.noPackagesCache || false);
   jspmPattern.watched = false;
   files.unshift(jspmPattern);
 

--- a/src/init.js
+++ b/src/init.js
@@ -86,7 +86,7 @@ module.exports = function(files, basePath, jspm, client) {
 
   // Allow Karma to serve all files within jspm_packages.
   // This allows jspm/SystemJS to load them
-  var jspmPattern = createServedPattern(packagesPath + '**/*', jspm.noPackagesCache || false);
+  var jspmPattern = createServedPattern(packagesPath + '**/*', jspm.cachePackages !== true);
   jspmPattern.watched = false;
   files.unshift(jspmPattern);
 


### PR DESCRIPTION
This solves OSX bug with `EMFILE: too many open files`. The default is not changed, the change is proposed as an option to include in config file.

![image](https://cloud.githubusercontent.com/assets/1777005/12943016/ccce0c72-cfde-11e5-8dd2-65b97d1128d1.png)