### PR TITLE
CP-1392 Redirected errors during System().import to karma().error.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -60,7 +60,7 @@
         promiseChain.then(function () {
             karma.start();
         }, function (e) {
-            throw e;
+            karma.error(e.name + ": " + e.message);
         });
     };
 


### PR DESCRIPTION
Fixes #128

The issue in #128 was that if the `System.import()` function failed, then all the browsers would disconnect with a "Potentially unhandled rejection". This is mostly annoying for `SyntaxErrors`.

By catching the errors from System.import, and redirecting the message to karma.error(), karma-jspm is improved in the following ways:
 - The error is instead printed nicely in the terminal, allowing the user to understand the error.
 - The the browsers stay alive, such that the user can simply fix the syntax error and save, triggering a new test run.
 - Not having to restart karma every time you make a syntax error.

Before a syntax error would result in the following output:

    PhantomJS 2.1.1 (Linux 0.0.0) ERROR: 'Potentially unhandled rejection [3] eval@[native code]
    __exec@http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:1395:16
    execute@http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:3521:20
    linkDynamicModule@http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:3126:36
    link@http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:2969:28
    execute@http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:3301:17
    doDynamicExecute@http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:703:32
    link@http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:905:36
    doLink@http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:557:11
    updateLinkSetOnLoad@http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:605:24
    http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:417:30
    tryCatchReject@http://localhost:9877/base/jspm_packages/system-polyfills.src.js?3aa57969dce4ecea4c51aab540f372d15cc886b6:1252:34
    runContinuation1@http://localhost:9877/base/jspm_packages/system-polyfills.src.js?3aa57969dce4ecea4c51aab540f372d15cc886b6:1211:18
    when@http://localhost:9877/base/jspm_packages/system-polyfills.src.js?3aa57969dce4ecea4c51aab540f372d15cc886b6:999:20
    run@http://localhost:9877/base/jspm_packages/system-polyfills.src.js?3aa57969dce4ecea4c51aab540f372d15cc886b6:890:17
    _drain@http://localhost:9877/base/jspm_packages/system-polyfills.src.js?3aa57969dce4ecea4c51aab540f372d15cc886b6:166:22
    drain@http://localhost:9877/base/jspm_packages/system-polyfills.src.js?3aa57969dce4ecea4c51aab540f372d15cc886b6:131:15'

    Chrome 48.0.2564 (Linux 0.0.0) ERROR: 'Potentially unhandled rejection [3] SyntaxError: missing ) after argument list
    	Evaluating http://localhost:9877/base/test/brokentest.js
    	Error loading http://localhost:9877/base/test/brokentest.js
        at eval (native)
        at SystemJSLoader.__exec (http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:1395:16)
        at entry.execute (http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:3521:16)
        at linkDynamicModule (http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:3126:32)
        at link (http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:2969:11)
        at Object.execute (http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:3301:13)
        at doDynamicExecute (http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:703:25)
        at link (http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:905:20)
        at doLink (http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:557:7)
        at updateLinkSetOnLoad (http://localhost:9877/base/jspm_packages/system.src.js?38538ebca96bc7b222f7e7ba15943f173a485f6e:605:18)'

    19 02 2016 13:17:04.301:WARN [PhantomJS 2.1.1 (Linux 0.0.0)]: Disconnected (1 times), because no message in 10000 ms.

    19 02 2016 13:17:04.344:WARN [Chrome 48.0.2564 (Linux 0.0.0)]: Disconnected (1 times), because no message in 10000 ms.

With this pull request, the output is instead:

    PhantomJS 2.1.1 (Linux 0.0.0) ERROR
      SyntaxError: Expected token ')'
      	Evaluating /home/frederiknjs/Code/personal/karma/test/brokentest.js
      	Error loading /home/frederiknjs/Code/personal/karma/test/brokentest.js

    Chrome 48.0.2564 (Linux 0.0.0) ERROR
      SyntaxError: missing ) after argument list
      	Evaluating /home/frederiknjs/Code/personal/karma/test/brokentest.js
      	Error loading /home/frederiknjs/Code/personal/karma/test/brokentest.js

Hope you like it :-)