### PR TITLE
CP-1770 expandedFiles now update when files are added/removed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@
 
 var initJspm = require('./src/init');
 
-initJspm.$inject = ['config.files', 'config.basePath', 'config.jspm', 'config.client'];
+initJspm.$inject = ['config.files', 'config.basePath', 'config.jspm', 'config.client', 'emitter'];
 
 module.exports = {
   'framework:jspm': ['factory', initJspm]

--- a/src/init.js
+++ b/src/init.js
@@ -58,7 +58,7 @@ function getJspmPackageJson(dir) {
   return pjson;
 }
 
-module.exports = function(files, basePath, jspm, client) {
+module.exports = function(files, basePath, jspm, client, emitter) {
   // Initialize jspm config if it wasn't specified in karma.conf.js
   if(!jspm)
     jspm = {};
@@ -115,10 +115,15 @@ module.exports = function(files, basePath, jspm, client) {
   // 1. Add all the files as "served" files to the files array
   // 2. Expand out and globs to end up with actual files for jspm to load.
   //    Store that in client.jspm.expandedFiles
-  client.jspm.expandedFiles = flatten(jspm.loadFiles.map(function(file){
-    files.push(createServedPattern(basePath + "/" + (file.pattern || file), file.nocache || false));
-    return expandGlob(file, basePath);
-  }));
+  function addExpandedFiles() {
+    client.jspm.expandedFiles = flatten(jspm.loadFiles.map(function(file){
+      files.push(createServedPattern(basePath + "/" + (file.pattern || file), file.nocache || false));
+      return expandGlob(file, basePath);
+    }));
+  }
+  addExpandedFiles();
+
+  emitter.on('file_list_modified', addExpandedFiles);
 
   // Add served files to files array
   jspm.serveFiles.map(function(file){

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -7,7 +7,7 @@ var normalPath = function(path){
 }
 
 describe('jspm plugin init', function(){
-    var files, jspm, client;
+    var files, jspm, client, emitter;
     var basePath = path.resolve(__dirname, '..');
 
     beforeEach(function(){
@@ -20,8 +20,11 @@ describe('jspm plugin init', function(){
             serveFiles: ['testfile.js']
         };
         client = {};
+        emitter = {
+            on: function() {}
+        }
 
-        initJspm(files, basePath, jspm, client);
+        initJspm(files, basePath, jspm, client, emitter);
     });
 
     it('should add config.js to the top of the files array', function(){


### PR DESCRIPTION
Fixes #121

I was quite annoyed that `karma-jspm` didn't load new files when they were added. So I found out that there is a `file_list_modified` event emitted from `karma`, when the file list changes. I simply injected the emitter and wrapped the `expandedFiles` assignment in it.

I have tested the change against one of my own projects, and running karma in watch mode now correctly loads new files when I add them.

Hope you like it ;-)