### PR TITLE
CP-1341 Release karma-jspm 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-jspm",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Include jspm module loader for karma runs; allows dynamic loading of src and test files and modules",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
PRs contained in this release:

https://github.com/Workiva/karma-jspm/pull/130, Redirected errors during System.import to karma.error.

https://github.com/Workiva/karma-jspm/pull/134, Update gulp-jasmine dependency - fixes #133

https://github.com/Workiva/karma-jspm/pull/137  Update README.md, karma-jspm 

https://github.com/Workiva/karma-jspm/pull/129  Support for JSPM 0.17 Beta

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/karma-jspm/compare/2.0.3...Release_2.1.0

