### PR TITLE
CP-1789 Enable karma file descriptions for loadFiles array

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -126,7 +126,7 @@ module.exports = function(files, basePath, jspm, client) {
 
   // Allow Karma to serve all files within jspm_packages.
   // This allows jspm/SystemJS to load them
-  var jspmPattern = createServedPattern(packagesPath + '**/*', jspm.cachePackages !== true);
+  var jspmPattern = createServedPattern(packagesPath + '**/*', {nocache: jspm.cachePackages !== true});
   jspmPattern.watched = false;
   files.push(jspmPattern);
 };

--- a/src/init.js
+++ b/src/init.js
@@ -31,9 +31,14 @@ var createPattern = function(path) {
   return {pattern: path, included: true, served: true, watched: false};
 };
 
-var createServedPattern = function(path, nocache){
-  nocache = nocache || false;
-  return {pattern: path, included: false, served: true, nocache:nocache, watched: true};
+var createServedPattern = function(path, file){
+  return {
+    pattern: path,
+    included: file && "included" in file ? file.included : false,
+    served: file && "served" in file ? file.served : true,
+    nocache: file && "nocache" in file ? file.nocache : false,
+    watched: file && "watched" in file ? file.watched : true
+  };
 };
 
 function getJspmPackageJson(dir) {
@@ -110,7 +115,7 @@ module.exports = function(files, basePath, jspm, client) {
   // 2. Expand out and globs to end up with actual files for jspm to load.
   //    Store that in client.jspm.expandedFiles
   client.jspm.expandedFiles = flatten(jspm.loadFiles.map(function(file){
-    files.push(createServedPattern(basePath + "/" + (file.pattern || file), file.nocache || false));
+    files.push(createServedPattern(basePath + "/" + (file.pattern || file), typeof file !== "string" ? file : null));
     return expandGlob(file, basePath);
   }));
 

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -15,7 +15,7 @@ describe('jspm plugin init', function(){
         jspm = {
             browser: 'custom_browser.js',
             config: 'custom_config.js',
-            loadFiles: ['src/**/*.js',{pattern:'not-cached.js', nocache:true}],
+            loadFiles: ['src/**/*.js',{pattern:'not-cached.js', nocache:true}, {pattern:'not-watched.js', watched:false}],
             packages: 'custom_packages/',
             serveFiles: ['testfile.js']
         };
@@ -68,10 +68,18 @@ describe('jspm plugin init', function(){
     });
 
     it('should assign true to nocache option to served files with nocache option in jspm.loadFiles', function(){
-        expect(normalPath(files[files.length - 2].pattern)).toEqual(normalPath(cwd + '/not-cached.js'));
+        expect(normalPath(files[files.length - 3].pattern)).toEqual(normalPath(cwd + '/not-cached.js'));
+        expect(files[files.length - 3].included).toEqual(false);
+        expect(files[files.length - 3].served).toEqual(true);
+        expect(files[files.length - 3].watched).toEqual(true);
+        expect(files[files.length - 3].nocache).toEqual(true);
+    });
+
+    it('should respect watched flag when adding jspm.loadFiles to served files', function(){
+        expect(normalPath(files[files.length - 2].pattern)).toEqual(normalPath(cwd + '/not-watched.js'));
         expect(files[files.length - 2].included).toEqual(false);
         expect(files[files.length - 2].served).toEqual(true);
-        expect(files[files.length - 2].watched).toEqual(true);
-        expect(files[files.length - 2].nocache).toEqual(true);
+        expect(files[files.length - 2].watched).toEqual(false);
+        expect(files[files.length - 2].nocache).toEqual(false);
     });
 });

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -53,33 +53,33 @@ describe('jspm plugin init', function(){
         expect(client.jspm.expandedFiles).toEqual(['src/adapter.js', 'src/init.js']);
     });
 
-    it('should add files from jspm.serveFiles to the end of the files array as served files', function(){
-        expect(normalPath(files[files.length - 1].pattern)).toEqual(normalPath(cwd + '/testfile.js'));
-        expect(files[files.length - 1].included).toEqual(false);
-        expect(files[files.length - 1].served).toEqual(true);
-        expect(files[files.length - 1].watched).toEqual(true);
+    it('should add files from jspm.serveFiles to the files array as served files', function(){
+        expect(normalPath(files[files.length - 2].pattern)).toEqual(normalPath(cwd + '/testfile.js'));
+        expect(files[files.length - 2].included).toEqual(false);
+        expect(files[files.length - 2].served).toEqual(true);
+        expect(files[files.length - 2].watched).toEqual(true);
     });
 
-    it('should use the configured jspm_packages path and include it in the files array', function(){
-        expect(normalPath(files[5].pattern)).toEqual(normalPath(path.resolve(cwd, './custom_packages/**/*')));
-        expect(files[5].included).toEqual(false);
-        expect(files[5].served).toEqual(true);
-        expect(files[5].watched).toEqual(false);
+    it('should use the configured jspm_packages path and include it at the end of the files array', function(){
+        expect(normalPath(files[files.length - 1].pattern)).toEqual(normalPath(path.resolve(cwd, './custom_packages/**/*')));
+        expect(files[files.length - 1].included).toEqual(false);
+        expect(files[files.length - 1].served).toEqual(true);
+        expect(files[files.length - 1].watched).toEqual(false);
     });
 
     it('should assign true to nocache option to served files with nocache option in jspm.loadFiles', function(){
-        expect(normalPath(files[files.length - 3].pattern)).toEqual(normalPath(cwd + '/not-cached.js'));
-        expect(files[files.length - 3].included).toEqual(false);
-        expect(files[files.length - 3].served).toEqual(true);
-        expect(files[files.length - 3].watched).toEqual(true);
-        expect(files[files.length - 3].nocache).toEqual(true);
+        expect(normalPath(files[files.length - 4].pattern)).toEqual(normalPath(cwd + '/not-cached.js'));
+        expect(files[files.length - 4].included).toEqual(false);
+        expect(files[files.length - 4].served).toEqual(true);
+        expect(files[files.length - 4].watched).toEqual(true);
+        expect(files[files.length - 4].nocache).toEqual(true);
     });
 
     it('should respect watched flag when adding jspm.loadFiles to served files', function(){
-        expect(normalPath(files[files.length - 2].pattern)).toEqual(normalPath(cwd + '/not-watched.js'));
-        expect(files[files.length - 2].included).toEqual(false);
-        expect(files[files.length - 2].served).toEqual(true);
-        expect(files[files.length - 2].watched).toEqual(false);
-        expect(files[files.length - 2].nocache).toEqual(false);
+        expect(normalPath(files[files.length - 3].pattern)).toEqual(normalPath(cwd + '/not-watched.js'));
+        expect(files[files.length - 3].included).toEqual(false);
+        expect(files[files.length - 3].served).toEqual(true);
+        expect(files[files.length - 3].watched).toEqual(false);
+        expect(files[files.length - 3].nocache).toEqual(false);
     });
 });


### PR DESCRIPTION
This change enables the full [file description](http://karma-runner.github.io/0.13/config/files.html) capabilities of karma to the `loadFiles` array instead of only passing through the nocache flag.

For example you can now disable watching for changes on the files you want to load.
I use this feature to only watch bundles for changes, which integrates gracefully with jspm's [development bundling](http://jspm.io/0.17-beta-guide/development-bundling.html) feature (you can reuse your bundle you built for the dev server to execute your tests by providing your spec modules within the bundle).