### PR TITLE
CP-1790 Replace gulp-jasmine by plain jasmine

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,0 @@
-var gulp = require('gulp'),
-    jasmine = require('gulp-jasmine');
-
-
-gulp.task('test', function(){
-    gulp.src('test/**/*.spec.js')
-        .pipe(jasmine());
-});
-

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "jspm"
   ],
   "scripts": {
-    "test": "gulp test"
+    "test": "cross-env JASMINE_CONFIG_PATH=test/jasmine.json jasmine 'test/**/*.spec.js'"
   },
   "author": {
     "name": "Max Peterson",
@@ -30,7 +30,7 @@
     "glob": "~3.2"
   },
   "devDependencies": {
-    "gulp": "^3.8.7",
-    "gulp-jasmine": "^2.3.0"
+    "cross-env": "^1.0.7",
+    "jasmine": "^2.4.1"
   }
 }

--- a/test/jasmine.json
+++ b/test/jasmine.json
@@ -1,0 +1,8 @@
+{
+  "spec_dir": "test",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
The problem with the gulp-jasmine plugin was that failing tests
do not make the travis build fail.
By using plain jasmine we achieve this failing of the tests.
As a nice side effect our dependencies are much more light-weight
and the tests are executed faster.

Resolves #153

Note: At the moment this test fails, since the tests are failing in the master branch.