### PR TITLE
CP-1962 support jspm.config as array

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -88,7 +88,10 @@ module.exports = function(files, basePath, jspm, client, emitter) {
 
     var packagesPath = path.normalize(basePath + '/' + jspm.packages + '/');
     var browserPath = path.normalize(basePath + '/' + jspm.browser);
-    var configPath = path.normalize(basePath + '/' + jspm.config);
+    var configFiles = Array.isArray(jspm.config) ? jspm.config : [jspm.config];
+    var configPaths = configFiles.map(function(config) {
+        return path.normalize(basePath + '/' + config);
+    });
 
     // Add SystemJS loader and jspm config
     function getLoaderPath(fileName){
@@ -99,8 +102,13 @@ module.exports = function(files, basePath, jspm, client, emitter) {
             return packagesPath + fileName + '.js';
         }
     }
-    files.unshift(createPattern(configPath));
-
+    
+    Array.prototype.unshift.apply(files,
+        configPaths.map(function(configPath) {
+            return createPattern(configPath)
+        })
+    );
+    
     // Needed for JSPM 0.17 beta
     if(jspm.browser) {
         files.unshift(createPattern(browserPath));

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -39,6 +39,14 @@ describe('jspm plugin init', function(){
         expect(files[3].included).toEqual(true);
     });
 
+    it('should support an array of config files', function() {
+        jspm.config = ['custom_config.js', 'another_config.js'];
+        files = [];
+        initJspm(files, basePath, jspm, client, emitter);
+        expect(normalPath(files[4].pattern)).toEqual(normalPath(basePath + '/custom_config.js'));
+        expect(normalPath(files[5].pattern)).toEqual(normalPath(basePath + '/another_config.js'));
+    });
+
     it('should add adapter.js to the top of the files array', function(){
         expect(normalPath(files[2].pattern)).toEqual(normalPath(basePath + '/src/adapter.js'));
         expect(files[2].included).toEqual(true);


### PR DESCRIPTION
we have a slightly big project that involves several connected projects. We often load more then one files that contains systemjs configuration.

(using `jspm.browser.js` can be considered a specialized use case, and the current jspm.browser should be deprecated IMO)