### PR TITLE
Fixes #158 - add options for dev/node config files

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -89,6 +89,8 @@ module.exports = function(files, basePath, jspm, client, emitter) {
     var packagesPath = path.normalize(basePath + '/' + jspm.packages + '/');
     var browserPath = path.normalize(basePath + '/' + jspm.browser);
     var configPath = path.normalize(basePath + '/' + jspm.config);
+    var devConfigPath = path.normalize(basePath + '/' + jspm.devConfig);
+    var nodeConfigPath = path.normalize(basePath + '/' + jspm.nodeConfig);
 
     // Add SystemJS loader and jspm config
     function getLoaderPath(fileName){
@@ -104,6 +106,14 @@ module.exports = function(files, basePath, jspm, client, emitter) {
     // Needed for JSPM 0.17 beta
     if(jspm.browser) {
         files.unshift(createPattern(browserPath));
+    }
+
+    // Added in JSPM 0.17-beta.17
+    if(jspm.devConfig) {
+        files.push(createPattern(devConfigPath));
+    }
+    if(jspm.nodeConfig) {
+        files.push(createPattern(nodeConfigPath));
     }
 
     files.unshift(createPattern(__dirname + '/adapter.js'));

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -17,6 +17,8 @@ describe('jspm plugin init', function(){
         jspm = {
             browser: 'custom_browser.js',
             config: 'custom_config.js',
+            devConfig: 'custom_dev_config.js',
+            nodeConfig: 'custom_node_config.js',
             loadFiles: ['src/**/*.js',{pattern:'not-cached.js', nocache:true}, {pattern:'not-watched.js', watched:false}],
             packages: 'custom_packages/',
             serveFiles: ['testfile.js']
@@ -37,6 +39,16 @@ describe('jspm plugin init', function(){
     it('should add browser.js to the top of the files array', function(){
         expect(normalPath(files[3].pattern)).toEqual(normalPath(basePath + '/custom_browser.js'));
         expect(files[3].included).toEqual(true);
+    });
+
+    it('should add dev.js after the browser and config in the files array', function(){
+        expect(normalPath(files[5].pattern)).toEqual(normalPath(basePath + '/custom_dev_config.js'));
+        expect(files[5].included).toEqual(true);
+    });
+
+    it('should add node.js after the browser and config in the files array', function(){
+        expect(normalPath(files[6].pattern)).toEqual(normalPath(basePath + '/custom_node_config.js'));
+        expect(files[6].included).toEqual(true);
     });
 
     it('should add adapter.js to the top of the files array', function(){


### PR DESCRIPTION
This adds two more config file options that are available in jspm 0.17 beta