### PR TITLE
Support jspm.dev.js for JSPM beta.15+

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ jspm: {
 }
 ```
 
+For JSPM 0.17beta.15 or above, you may also (optionally) need to specify the `jspm.dev.js` file.
+
+```js
+jspm: {
+    devConfig: "myJspmDevConfig.js",
+}
+```
+
 You may want to make additional files/a file pattern available for jspm to load, but not load it right away. Simply add that to `serveFiles`. 
 One use case for this is to only put test specs in `loadFiles`, and jspm will only load the src files when and if the test files require them. Such a config would look like this:
 

--- a/src/init.js
+++ b/src/init.js
@@ -89,6 +89,7 @@ module.exports = function(files, basePath, jspm, client, emitter) {
     var packagesPath = path.normalize(basePath + '/' + jspm.packages + '/');
     var browserPath = path.normalize(basePath + '/' + jspm.browser);
     var configPath = path.normalize(basePath + '/' + jspm.config);
+    var devConfigPath = path.normalize(basePath + '/' + jspm.devConfig);
 
     // Add SystemJS loader and jspm config
     function getLoaderPath(fileName){
@@ -99,6 +100,12 @@ module.exports = function(files, basePath, jspm, client, emitter) {
             return packagesPath + fileName + '.js';
         }
     }
+
+    // Needed for JSPM 0.17 beta.15 and higher
+    if(jspm.devConfig) {
+        files.unshift(createPattern(devConfigPath));
+    }
+
     files.unshift(createPattern(configPath));
 
     // Needed for JSPM 0.17 beta

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -17,6 +17,7 @@ describe('jspm plugin init', function(){
         jspm = {
             browser: 'custom_browser.js',
             config: 'custom_config.js',
+            devConfig: 'custom_dev_config.js',
             loadFiles: ['src/**/*.js',{pattern:'not-cached.js', nocache:true}, {pattern:'not-watched.js', watched:false}],
             packages: 'custom_packages/',
             serveFiles: ['testfile.js']
@@ -27,6 +28,11 @@ describe('jspm plugin init', function(){
         };
 
         initJspm(files, basePath, jspm, client, emitter);
+    });
+
+    it('should add devConfig.js to the top of the files array', function() {
+        expect(normalPath(files[5].pattern)).toEqual(normalPath(basePath + '/custom_dev_config.js'));
+        expect(files[5].included).toEqual(true);
     });
 
     it('should add config.js to the top of the files array', function(){


### PR DESCRIPTION
In configurations which rely on JSPM to transpile/build at runtime, the
newly-added (optional) `jspm.dev.js` file may be required.