### PR TITLE
add adapter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Karma auto loads plugins unless you specify a plugins config. If you have one, y
 plugins: ['karma-jspm', 'karma-phantomjs-launcher'],
 ```
 
-The `loadFiles` configuration tells karma-jspm which files should be dynamically loaded via systemjs *before* the tests run. Globs or regular file paths are acceptable. 
+The `loadFiles` configuration tells karma-jspm which files should be dynamically loaded via systemjs *before* the tests run. Globs or regular file paths are acceptable.
 
 
 **You should not include these in the regular karma files array.** karma-jspm takes care of this for you.
@@ -59,7 +59,7 @@ jspm: {
 }
 ```
 
-You may want to make additional files/a file pattern available for jspm to load, but not load it right away. Simply add that to `serveFiles`. 
+You may want to make additional files/a file pattern available for jspm to load, but not load it right away. Simply add that to `serveFiles`.
 One use case for this is to only put test specs in `loadFiles`, and jspm will only load the src files when and if the test files require them. Such a config would look like this:
 
 ```js
@@ -79,7 +79,7 @@ jspm: {
 
 Depending on your framework and project structure it might be necessary to override jspm paths for the testing scenario.
 In order to do so just add the `paths` property to the jspm config object in your karma-configuration file, along with the overrides:
- 
+
 ```js
 jspm: {
     paths: {
@@ -87,7 +87,7 @@ jspm: {
         ...
     }
 }
-``` 
+```
 
 By default the plugin will strip the file extension of the js files. To disable that, specify the `stripExtension` option:
 
@@ -102,5 +102,13 @@ Most of the time, you do not want to cache your entire jspm_packages directory, 
 ```js
 jspm: {
     cachePackages: true
+}
+```
+
+By default, and adapter is provided to launch unit tests. You may provide a custom adapter:
+
+```js
+jspm: {
+    adapter: 'youradapter.js'
 }
 ```

--- a/src/init.js
+++ b/src/init.js
@@ -81,6 +81,10 @@ module.exports = function(files, basePath, jspm, client, emitter) {
         client.jspm.paths = jspm.paths;
     if(jspm.meta !== undefined && typeof jspm.meta === 'object')
         client.jspm.meta = jspm.meta;
+    if(!jspm.adapter)
+        jspm.adapter = __dirname + '/adapter.js';
+    else
+        jspm.adapter = path.normalize(basePath + '/' + jspm.adapter);
 
     // Pass on options to client
     client.jspm.useBundles = jspm.useBundles;
@@ -102,19 +106,19 @@ module.exports = function(files, basePath, jspm, client, emitter) {
             return packagesPath + fileName + '.js';
         }
     }
-    
+
     Array.prototype.unshift.apply(files,
         configPaths.map(function(configPath) {
             return createPattern(configPath)
         })
     );
-    
+
     // Needed for JSPM 0.17 beta
     if(jspm.browser) {
         files.unshift(createPattern(browserPath));
     }
 
-    files.unshift(createPattern(__dirname + '/adapter.js'));
+    files.unshift(createPattern(jspm.adapter));
     files.unshift(createPattern(getLoaderPath('system-polyfills.src')));
     files.unshift(createPattern(getLoaderPath('system.src')));
 

--- a/test/testInit.spec.js
+++ b/test/testInit.spec.js
@@ -96,3 +96,32 @@ describe('jspm plugin init', function(){
         expect(files[files.length - 3].nocache).toEqual(false);
     });
 });
+
+describe('jspm plugin init with adapter', function(){
+    var files, jspm, client, emitter;
+    var basePath = path.resolve(__dirname, '..');
+
+    beforeEach(function(){
+        files = [];
+        jspm = {
+            browser: 'custom_browser.js',
+            config: 'custom_config.js',
+            loadFiles: ['src/**/*.js',{pattern:'not-cached.js', nocache:true}, {pattern:'not-watched.js', watched:false}],
+            packages: 'custom_packages/',
+            serveFiles: ['testfile.js'],
+            adapter: 'custom_adapter.js'
+        };
+        client = {};
+        emitter = {
+            on: function() {}
+        };
+
+        initJspm(files, basePath, jspm, client, emitter);
+    });
+
+    it('should add custom adapter.js to the top of the files array', function(){
+        expect(normalPath(files[2].pattern)).toEqual(normalPath(basePath + '/custom_adapter.js'));
+        expect(files[2].included).toEqual(true);
+    });
+
+});


### PR DESCRIPTION
This PR is related to #164 and potentially #162.

This is a non-breaking change in that if no custom adapter is provided, the default adapter is used.

A sample implementation is here: https://github.com/UIUXEngineering/angular2-seed-jspm/blob/master/src/client/jspm.karma.ng2.adapter.js
