### PR TITLE
Remove extra function wrap

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -55,9 +55,7 @@
         var promiseChain = Promise.resolve();
         for (var i = 0; i < karma.config.jspm.expandedFiles.length; i++) {
             promiseChain = promiseChain.then((function (moduleName) {
-                return function () {
-                    return System['import'](moduleName);
-                };
+                return System['import'](moduleName);
             })(extractModuleName(karma.config.jspm.expandedFiles[i])));
         }
 


### PR DESCRIPTION
Fix #169 

`System.import()` returns a promise.
`.then()` accepts a promise in return, not a function.
