### PR TITLE
CP-2409 Update glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "git@github.com:Workiva/karma-jspm.git"
   },
   "dependencies": {
-    "glob": "~3.2"
+    "glob": "~7.0.5"
   },
   "devDependencies": {
     "cross-env": "^1.0.7",


### PR DESCRIPTION
Currently installing `karma-jspm` gives a warning:

```
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

This PR updates the `glob` dependency to the most recent version which uses an updated `minimatch` version as well.

I ran the tests after the change and they all still pass.

This PR should also fix #166.