### PR TITLE
Another approach for code coverage measurement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+escodegen.js

--- a/buildEscodegen.js
+++ b/buildEscodegen.js
@@ -1,0 +1,18 @@
+var cjsify = require('commonjs-everywhere').cjsify;
+var fs = require('fs');
+var escodegen = require('escodegen');
+
+fs.writeFileSync('./escodegen.js', '(function () {\n' +
+    '\'use strict\';\n' +
+    'global.escodegen = require(\'escodegen\');\n' +
+    'escodegen.browser = true;\n' +
+    '}());\n');
+
+var result = cjsify('./escodegen.js', process.cwd(), {aliases: {'path': ''}});
+var code = escodegen.generate(result, {
+    sourceMap: false,
+    sourceMapWithCode: false,
+    format: escodegen.FORMAT_MINIFY
+});
+fs.writeFileSync('./escodegen.js', code);
+

--- a/entrypointEsCodegen.js
+++ b/entrypointEsCodegen.js
@@ -1,1 +1,0 @@
-(function () {'use strict';global.escodegen = require('escodegen');escodegen.browser = true;}());

--- a/entrypointEsCodegen.js
+++ b/entrypointEsCodegen.js
@@ -1,0 +1,1 @@
+(function () {'use strict';global.escodegen = require('escodegen');escodegen.browser = true;}());

--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@
 
 var initJspm = require('./src/init');
 
-initJspm.$inject = ['config.files', 'config.basePath', 'config.jspm', 'config.client', 'emitter'];
+initJspm.$inject = ['config.files', 'config.basePath', 'config.jspm', 'config.reporters', 'config.client', 'emitter'];
 
 module.exports = {
-  'framework:jspm': ['factory', initJspm]
+  'framework:jspm': ['factory', initJspm],
+  'reporter:jspm': ['type', require('./src/reporter')]
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "scripts":         {
         "test":        "cross-env JASMINE_CONFIG_PATH=test/jasmine.json jasmine 'test/**/*.spec.js'",
         "lint":        "eslint **/*.js",
-        "postinstall": "node node_modules/commonjs-everywhere/bin/cjsify -ma path: entrypointEsCodegen.js > escodegen.js"
+        "postinstall": "node buildEscodegen.js"
     },
     "author":          {
         "name":  "Max Peterson",
@@ -33,7 +33,7 @@
         "istanbul":            "^0.4.3",
         "Base64":              "^1.0.0",
         "lodash":              "^4.15.0",
-        "escodegen":           "^1.4.0",
+        "escodegen":           "^1.8.1",
         "esprima":             "^2.7.3",
         "commonjs-everywhere": "^0.9.7",
         "karma-coverage":      "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,38 +1,48 @@
 {
-  "name": "karma-jspm",
-  "version": "2.2.0",
-  "description": "Include jspm module loader for karma runs; allows dynamic loading of src and test files and modules",
-  "main": "index.js",
-  "keywords": [
-    "karma-plugin",
-    "karma-adapter",
-    "jspm"
-  ],
-  "scripts": {
-    "test": "cross-env JASMINE_CONFIG_PATH=test/jasmine.json jasmine 'test/**/*.spec.js'",
-    "lint": "eslint **/*.js"
-  },
-  "author": {
-    "name": "Max Peterson",
-    "email": "maxwell.peterson@workiva.com"
-  },
-  "contributors": [
-    {
-      "name": "Max Peterson",
-      "email": "computmaxer@gmail.com"
+    "name":            "karma-jspm",
+    "version":         "2.2.0",
+    "description":     "Include jspm module loader for karma runs; allows dynamic loading of src and test files and modules",
+    "main":            "index.js",
+    "keywords":        [
+        "karma-plugin",
+        "karma-adapter",
+        "jspm"
+    ],
+    "scripts":         {
+        "test":        "cross-env JASMINE_CONFIG_PATH=test/jasmine.json jasmine 'test/**/*.spec.js'",
+        "lint":        "eslint **/*.js",
+        "postinstall": "node node_modules/commonjs-everywhere/bin/cjsify -ma path: entrypointEsCodegen.js > escodegen.js"
+    },
+    "author":          {
+        "name":  "Max Peterson",
+        "email": "maxwell.peterson@workiva.com"
+    },
+    "contributors":    [
+        {
+            "name":  "Max Peterson",
+            "email": "computmaxer@gmail.com"
+        }
+    ],
+    "license":         "Apache-2.0",
+    "repository":      {
+        "type": "git",
+        "url":  "git@github.com:Workiva/karma-jspm.git"
+    },
+    "dependencies":    {
+        "glob":                "~7.0.5",
+        "istanbul":            "^0.4.3",
+        "Base64":              "^1.0.0",
+        "lodash":              "^4.15.0",
+        "escodegen":           "^1.4.0",
+        "esprima":             "^2.7.3",
+        "commonjs-everywhere": "^0.9.7",
+        "karma-coverage":      "^1.1.1",
+        "minimatch":           "^3.0.0",
+        "remap-istanbul":      "^0.6.4"
+    },
+    "devDependencies": {
+        "cross-env": "^1.0.7",
+        "eslint":    "^2.10.2",
+        "jasmine":   "^2.4.1"
     }
-  ],
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:Workiva/karma-jspm.git"
-  },
-  "dependencies": {
-    "glob": "~7.0.5"
-  },
-  "devDependencies": {
-    "cross-env": "^1.0.7",
-    "eslint": "^2.10.2",
-    "jasmine": "^2.4.1"
-  }
 }

--- a/src/init.js
+++ b/src/init.js
@@ -133,13 +133,13 @@ module.exports = function (files, basePath, jspm, reporters, client, emitter) {
     files.unshift(createPattern(__dirname + '/adapter.js'));
     if (_.includes(reporters, 'jspm')) {
         // load istanbul directly in browser to instrument files after inplace transpiling
-        files.unshift(createPattern(__dirname + '/../node_modules/istanbul/lib/instrumenter.js'));
+        files.unshift(createPattern(require.resolve('istanbul/lib/instrumenter')));
         // ugly dependency, is build using postinstall script from escodegen dependency
         files.unshift(createPattern(__dirname + '/../escodegen.js'));
         // esprima is needed by istanbul
-        files.unshift(createPattern(__dirname + '/../node_modules/esprima/esprima.js'));
+        files.unshift(createPattern(require.resolve('esprima')));
         // base64 for older browsers
-        files.unshift(createPattern(__dirname + '/../node_modules/Base64/base64.js'));
+        files.unshift(createPattern(require.resolve('Base64')));
     }
     files.unshift(createPattern(getLoaderPath('system-polyfills.src')));
     files.unshift(createPattern(getLoaderPath('system.src')));

--- a/src/init.js
+++ b/src/init.js
@@ -17,27 +17,32 @@
 var glob = require('glob');
 var path = require('path');
 var fs = require('fs');
-
+var _ = require('lodash');
 
 function flatten(structure) {
     return [].concat.apply([], structure);
 }
 
 function expandGlob(file, cwd) {
-    return glob.sync(file.pattern || file, {cwd: cwd});
+    return glob.sync(file.pattern || file, { cwd: cwd });
 }
 
 var createPattern = function (path) {
-    return {pattern: path, included: true, served: true, watched: false};
+    return {
+        pattern:  path,
+        included: true,
+        served:   true,
+        watched:  false
+    };
 };
 
-var createServedPattern = function(path, file){
+var createServedPattern = function (path, file) {
     return {
-        pattern: path,
+        pattern:  path,
         included: file && 'included' in file ? file.included : false,
-        served: file && 'served' in file ? file.served : true,
-        nocache: file && 'nocache' in file ? file.nocache : false,
-        watched: file && 'watched' in file ? file.watched : true
+        served:   file && 'served' in file ? file.served : true,
+        nocache:  file && 'nocache' in file ? file.nocache : false,
+        watched:  file && 'watched' in file ? file.watched : true
     };
 };
 
@@ -50,37 +55,48 @@ function getJspmPackageJson(dir) {
         pjson = {};
     }
     if (pjson.jspm) {
-        for (var p in pjson.jspm)
+        for (var p in pjson.jspm) {
             pjson[p] = pjson.jspm[p];
+        }
     }
     pjson.directories = pjson.directories || {};
     if (pjson.directories.baseURL) {
-        if (!pjson.directories.packages)
+        if (!pjson.directories.packages) {
             pjson.directories.packages = path.join(pjson.directories.baseURL, 'jspm_packages');
-        if (!pjson.configFile)
+        }
+        if (!pjson.configFile) {
             pjson.configFile = path.join(pjson.directories.baseURL, 'config.js');
+        }
     }
     return pjson;
 }
 
-module.exports = function(files, basePath, jspm, client, emitter) {
+module.exports = function (files, basePath, jspm, reporters, client, emitter) {
     // Initialize jspm config if it wasn't specified in karma.conf.js
-    if(!jspm)
+    if (!jspm) {
         jspm = {};
-    if(!jspm.config)
+    }
+    if (!jspm.config) {
         jspm.config = getJspmPackageJson(basePath).configFile || 'config.js';
-    if(!jspm.loadFiles)
+    }
+    if (!jspm.loadFiles) {
         jspm.loadFiles = [];
-    if(!jspm.serveFiles)
+    }
+    if (!jspm.serveFiles) {
         jspm.serveFiles = [];
-    if(!jspm.packages)
+    }
+    if (!jspm.packages) {
         jspm.packages = getJspmPackageJson(basePath).directories.packages || 'jspm_packages/';
-    if(!client.jspm)
+    }
+    if (!client.jspm) {
         client.jspm = {};
-    if(jspm.paths !== undefined && typeof jspm.paths === 'object')
+    }
+    if (jspm.paths !== undefined && typeof jspm.paths === 'object') {
         client.jspm.paths = jspm.paths;
-    if(jspm.meta !== undefined && typeof jspm.meta === 'object')
+    }
+    if (jspm.meta !== undefined && typeof jspm.meta === 'object') {
         client.jspm.meta = jspm.meta;
+    }
 
     // Pass on options to client
     client.jspm.useBundles = jspm.useBundles;
@@ -89,14 +105,14 @@ module.exports = function(files, basePath, jspm, client, emitter) {
     var packagesPath = path.normalize(basePath + '/' + jspm.packages + '/');
     var browserPath = path.normalize(basePath + '/' + jspm.browser);
     var configFiles = Array.isArray(jspm.config) ? jspm.config : [jspm.config];
-    var configPaths = configFiles.map(function(config) {
+    var configPaths = configFiles.map(function (config) {
         return path.normalize(basePath + '/' + config);
     });
 
     // Add SystemJS loader and jspm config
-    function getLoaderPath(fileName){
+    function getLoaderPath(fileName) {
         var exists = glob.sync(packagesPath + fileName + '@*.js');
-        if(exists && exists.length != 0){
+        if (exists && exists.length != 0) {
             return packagesPath + fileName + '@*.js';
         } else {
             return packagesPath + fileName + '.js';
@@ -104,17 +120,27 @@ module.exports = function(files, basePath, jspm, client, emitter) {
     }
 
     Array.prototype.unshift.apply(files,
-        configPaths.map(function(configPath) {
+        configPaths.map(function (configPath) {
             return createPattern(configPath)
         })
     );
 
     // Needed for JSPM 0.17 beta
-    if(jspm.browser) {
+    if (jspm.browser) {
         files.unshift(createPattern(browserPath));
     }
 
     files.unshift(createPattern(__dirname + '/adapter.js'));
+    if (_.includes(reporters, 'jspm')) {
+        // load istanbul directly in browser to instrument files after inplace transpiling
+        files.unshift(createPattern(__dirname + '/../node_modules/istanbul/lib/instrumenter.js'));
+        // ugly dependency, is build using postinstall script from escodegen dependency
+        files.unshift(createPattern(__dirname + '/../escodegen.js'));
+        // esprima is needed by istanbul
+        files.unshift(createPattern(__dirname + '/../node_modules/esprima/esprima.js'));
+        // base64 for older browsers
+        files.unshift(createPattern(__dirname + '/../node_modules/Base64/base64.js'));
+    }
     files.unshift(createPattern(getLoaderPath('system-polyfills.src')));
     files.unshift(createPattern(getLoaderPath('system.src')));
 
@@ -128,19 +154,30 @@ module.exports = function(files, basePath, jspm, client, emitter) {
             return expandGlob(file, basePath);
         }));
     }
+
     addExpandedFiles();
 
     emitter.on('file_list_modified', addExpandedFiles);
 
     // Add served files to files array
-    jspm.serveFiles.map(function(file){
+    jspm.serveFiles.map(function (file) {
         files.push(createServedPattern(basePath + '/' + (file.pattern || file)));
     });
+
+    // store files for coverage
+    if (_.includes(reporters, 'jspm') && _.has(jspm, 'coverage') && _.isArray(jspm.coverage)) {
+        client.jspm.coverage = {};
+        jspm.coverage.map(function (file) {
+            expandGlob(file, basePath).map(function (file) {
+                client.jspm.coverage[file] = true;
+            });
+        });
+    }
 
     // Allow Karma to serve all files within jspm_packages.
     // This allows jspm/SystemJS to load them
     var jspmPattern = createServedPattern(
-        packagesPath + '!(system-polyfills.src.js|system.src.js)/**', {nocache: jspm.cachePackages !== true}
+        packagesPath + '!(system-polyfills.src.js|system.src.js)/**', { nocache: jspm.cachePackages !== true }
     );
     jspmPattern.watched = false;
     files.push(jspmPattern);

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,0 +1,21 @@
+var remapIstanbul = require('remap-istanbul');
+var karmaCoverageReport = require('karma-coverage/lib/reporter');
+
+function CoverageReporter(rootConfig, helper, logger, emitter) {
+    var log = logger.create('reporter-wrapper.coverage');
+    var config = rootConfig.coverageReporter = rootConfig.coverageReporter || {};
+    config._onWriteReport = function (collector) {
+        try {
+            collector = remapIstanbul.remap(collector.getFinalCoverage());
+        } catch(e) {
+            log.error(e);
+        }
+        return collector;
+    };
+    karmaCoverageReport.call(this, rootConfig, helper, logger, emitter);
+}
+
+CoverageReporter.$inject = karmaCoverageReport.$inject;
+
+// PUBLISH
+module.exports = CoverageReporter;


### PR DESCRIPTION
It was great to see an approach in https://github.com/Workiva/karma-jspm/pull/147 to measure code coverage while using jspm with karma. I searched very long for a transpiler agnostic and more simple attached reporter for karma. But the idea in https://github.com/Workiva/karma-jspm/pull/147 has drawbacks:

instrumented files are loaded twice (in preprocessor and while test running)
preprocessed code has file system relative paths
temp files are created for remapping
instrumented code is stored in jspm.config.coverage and this can be huge
storing instrumended code in causes unpredictable code generation for karma index file, because karma uses replace in https://github.com/karma-runner/karma/blob/master/lib/middleware/karma.js#L213 and that causes unwanted replacing, if you have RegExp expression with $' or $$ in your transpiled code

Thats why i create another implementation using istanbul directly while test running in the browser:
loading istanbul in the client with esprima and escoedgen (for that i must create a postinstall script to build a browser runable version)
polyfill added for base64 source map creation to run in older browsers
creating instrumenter with embed source to prevent temp files

I think the code is simpler and there is no need for a preprocessor. Feedback is welcome!

I have tested the code against a project with more than 450 tests in Chrome.  