### PR TITLE
Fix "Error" when using jspm v0.17.0-beta.35

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -48,7 +48,7 @@
 
         // Exclude bundle configurations if useBundles option is not specified
         if (!karma.config.jspm.useBundles) {
-            System.bundles = [];
+            System.config({ bundles: [] });
         }
 
         // Load everything specified in loadFiles in the specified order


### PR DESCRIPTION
jspm v0.17.0-beta.35 throw an error when it used with karma-jspm v2.2.0: 
```bash
Uncaught Error: Setting `SystemJS.bundles` directly is no longer supported. Use `SystemJS.config({ bundles: ... })`.
```
This commit will solve this issue. Instead of `System.bundles = [];`, `System.config({ bundles: [] });` should be used.